### PR TITLE
task-141/client socket console

### DIFF
--- a/console/.gitignore
+++ b/console/.gitignore
@@ -75,3 +75,6 @@ TAGS
 .project
 .cproject
 .settings/
+
+# Ignore .env file
+.env

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -4,4 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = "1.0.203"
+serde = { version = "1.0", features = ["derive"] }
+jni = "0.21.1"
+serde_json = "1.0"
+
+[lib]
+crate_type = ["cdylib"]

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -4,9 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
 jni = "0.21.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_derive = "1.0"
 serde_json = "1.0"
 
+
 [lib]
-crate_type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "client"
+path = "src/bin/client.rs"

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+serde = "1.0.203"

--- a/console/Cargo.toml
+++ b/console/Cargo.toml
@@ -8,7 +8,7 @@ jni = "0.21.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-
+dotenv = "0.15.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/console/src/bin/client.rs
+++ b/console/src/bin/client.rs
@@ -1,0 +1,5 @@
+extern crate console;
+
+fn main() {
+    console::run_client();
+}

--- a/console/src/bin/client.rs
+++ b/console/src/bin/client.rs
@@ -1,5 +1,6 @@
 extern crate console;
 
+// This is the entry point for the client and is used for testing purposes
 fn main() {
     console::run_client();
 }

--- a/console/src/frame.rs
+++ b/console/src/frame.rs
@@ -1,25 +1,31 @@
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Coord {
     pub x: i32,
     pub y: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Size {
     pub height: f64,
     pub width: f64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Sound {
     pub file_path: String,
     pub can_play: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Sprite {
     pub position: Coord,
     pub size: Size,
     pub is_hidden: bool,
+    pub file_path: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Frame {
+    pub sprite: Option<Sprite>,
     pub sound: Option<Sound>,
 }

--- a/console/src/frame.rs
+++ b/console/src/frame.rs
@@ -1,0 +1,25 @@
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Coord {
+    pub x: i32,
+    pub y: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Size {
+    pub height: f64,
+    pub width: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Sound {
+    pub file_path: String,
+    pub can_play: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Sprite {
+    pub position: Coord,
+    pub size: Size,
+    pub is_hidden: bool,
+    pub sound: Option<Sound>,
+}

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -1,0 +1,88 @@
+extern crate jni;
+
+use jni::JNIEnv;
+use jni::objects::{JObject, JClass, JString};
+
+#[derive(Debug)]
+struct Coord {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug)]
+struct Size {
+    height: f64,
+    width: f64,
+}
+
+#[derive(Debug)]
+struct Sound {
+    file_path: String,
+    can_play: bool,
+}
+
+#[derive(Debug)]
+struct Sprite {
+    position: Coord,
+    size: Size,
+    is_hidden: bool,
+    sound: Option<Sound>,
+}
+
+// Function to extract `Coord` from a `JObject`
+fn get_coord(env: &mut JNIEnv, coord_obj: &JObject) -> Coord {
+    let x = env.get_field(coord_obj, "x", "I").unwrap().i().unwrap();
+    let y = env.get_field(coord_obj, "y", "I").unwrap().i().unwrap();
+    Coord { x, y }
+}
+
+// Function to extract `Size` from a `JObject`
+fn get_size(env: &mut JNIEnv, size_obj: &JObject) -> Size {
+    let height = env.get_field(size_obj, "height", "D").unwrap().d().unwrap();
+    let width = env.get_field(size_obj, "width", "D").unwrap().d().unwrap();
+    Size { height, width }
+}
+
+// Function to extract `Sound` from a `JObject`
+fn get_sound(env: &mut JNIEnv, sound_obj: &JObject) -> Sound {
+    let file_path_obj = env.get_field(sound_obj, "filePath", "Ljava/lang/String;").unwrap().l().unwrap();
+    let file_path: String = env.get_string(&JString::from(file_path_obj)).unwrap().into();
+    let can_play = env.get_field(sound_obj, "canPlay", "Z").unwrap().z().unwrap();
+    Sound { file_path, can_play }
+}
+
+// Function to extract `Sprite` from a `JObject`
+fn get_sprite(env: &mut JNIEnv, sprite_obj: &JObject) -> Sprite {
+    let position_obj = env.get_field(sprite_obj, "position", "LCoord;").unwrap().l().unwrap();
+    let size_obj = env.get_field(sprite_obj, "size", "LSize;").unwrap().l().unwrap();
+    let is_hidden = env.get_field(sprite_obj, "isHidden", "Z").unwrap().z().unwrap();
+    
+    let sound_obj = env.get_field(sprite_obj, "sound", "LSound;").unwrap().l();
+    let sound = match sound_obj {
+        Ok(obj) => Some(get_sound(env, &obj)),
+        Err(_) => None,
+    };
+
+    Sprite {
+        position: get_coord(env, &position_obj),
+        size: get_size(env, &size_obj),
+        is_hidden,
+        sound,
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_example_RenderHandler_handleSprite(env: JNIEnv, _: JClass, sprite_obj: JObject) {
+    let mut env = env;
+    let sprite = get_sprite(&mut env, &sprite_obj);
+    // Handle sprite in Rust
+    println!("{:?}", sprite);
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_example_RenderHandler_handleSound(env: JNIEnv, _: JClass, sound_obj: JObject) {
+    let mut env = env;
+    let sound = get_sound(&mut env, &sound_obj);
+    // Handle sound in Rust
+    println!("{:?}", sound);
+}

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -8,6 +8,10 @@ pub mod frame;
 pub mod serialization;
 pub mod socket_client;
 
+use std::env;
+
+use dotenv::dotenv;
+
 use crate::frame::{Coord, Size, Sprite, Sound};
 use crate::serialization::serialize_to_json;
 use crate::socket_client::send_data_to_server;
@@ -28,8 +32,9 @@ fn simulate_data_reception() -> Sprite {
 }
 
 pub fn run_client() {
+    dotenv().ok();
+    let server_address = env::var("SERVER_ADDRESS").expect("SERVER_ADDRESS must be set");
     let sprite = simulate_data_reception();
     let json_data = serialize_to_json(&sprite);
-    let server_address = "127.0.0.1:8080";
-    send_data_to_server(&json_data, server_address);
+    send_data_to_server(&json_data, &server_address);
 }

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -1,34 +1,43 @@
 extern crate jni;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 
-use jni::JNIEnv;
-use jni::objects::{JObject, JClass, JString};
+pub mod frame;
+pub mod serialization;
+pub mod socket_client;
 
-#[derive(Debug)]
-struct Coord {
-    x: i32,
-    y: i32,
+use crate::frame::{Coord, Size, Sprite, Sound};
+use crate::serialization::serialize_to_json;
+use crate::socket_client::send_data_to_server;
+
+//use jni::JNIEnv;
+//use jni::objects::{JObject, JClass, JString};
+
+// Simulacion de datos
+fn simulate_data_reception() -> Sprite {
+    let position = Coord { x: 10, y: 20 };
+    let size = Size { height: 64.0, width: 64.0 };
+    let sound = Sound { file_path: String::from("/path/to/sound.wav"), can_play: true };
+    let sprite = Sprite {
+        position,
+        size,
+        is_hidden: false,
+        sound: Some(sound),
+    };
+
+    sprite
 }
 
-#[derive(Debug)]
-struct Size {
-    height: f64,
-    width: f64,
+pub fn run_client() {
+    let sprite = simulate_data_reception();
+    let json_data = serialize_to_json(&sprite);
+    let server_address = "127.0.0.1:8080";
+    send_data_to_server(&json_data, server_address);
 }
 
-#[derive(Debug)]
-struct Sound {
-    file_path: String,
-    can_play: bool,
-}
-
-#[derive(Debug)]
-struct Sprite {
-    position: Coord,
-    size: Size,
-    is_hidden: bool,
-    sound: Option<Sound>,
-}
-
+/* 
 // Function to extract `Coord` from a `JObject`
 fn get_coord(env: &mut JNIEnv, coord_obj: &JObject) -> Coord {
     let x = env.get_field(coord_obj, "x", "I").unwrap().i().unwrap();
@@ -86,3 +95,4 @@ pub extern "system" fn Java_com_example_RenderHandler_handleSound(env: JNIEnv, _
     // Handle sound in Rust
     println!("{:?}", sound);
 }
+*/

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -13,23 +13,26 @@ use std::{env, thread};
 
 use dotenv::dotenv;
 
-use crate::frame::{Coord, Size, Sprite, Sound};
+use crate::frame::{Coord, Size, Sprite, Sound, Frame};
 use crate::serialization::serialize_to_json;
 use crate::socket_client::send_data_to_server;
 
-// Simulacion de datos
-fn simulate_data_reception(x: i32, y: i32) -> Sprite {
-    let position = Coord { x, y};
+// Simulación de datos
+fn simulate_data_reception(x: i32, y: i32) -> Frame {
+    let position = Coord { x, y };
     let size = Size { height: 64.0, width: 64.0 };
-    let sound = Sound { file_path: String::from("assets/images/pacman.jpeg"), can_play: true };
+    let sound = Sound { file_path: String::from("assets/sounds/pacman_sound.wav"), can_play: true };
     let sprite = Sprite {
         position,
         size,
         is_hidden: false,
-        sound: Some(sound),
+        file_path: String::from("assets/images/pacman.jpeg"),
     };
 
-    sprite
+    Frame {
+        sprite: Some(sprite),
+        sound: Some(sound),
+    }
 }
 
 pub fn run_client() {
@@ -40,8 +43,8 @@ pub fn run_client() {
     let mut y = -100;
 
     for _ in 0..100 {
-        let sprite = simulate_data_reception(x, y);
-        let json_data = serialize_to_json(&sprite);
+        let frame = simulate_data_reception(x, y);
+        let json_data = serialize_to_json(&frame);
         send_data_to_server(&json_data, &server_address);
 
         x += 4;

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -8,7 +8,8 @@ pub mod frame;
 pub mod serialization;
 pub mod socket_client;
 
-use std::env;
+use std::time::Duration;
+use std::{env, thread};
 
 use dotenv::dotenv;
 
@@ -17,10 +18,10 @@ use crate::serialization::serialize_to_json;
 use crate::socket_client::send_data_to_server;
 
 // Simulacion de datos
-fn simulate_data_reception() -> Sprite {
-    let position = Coord { x: 10, y: 20 };
+fn simulate_data_reception(x: i32, y: i32) -> Sprite {
+    let position = Coord { x, y};
     let size = Size { height: 64.0, width: 64.0 };
-    let sound = Sound { file_path: String::from("/path/to/sound.wav"), can_play: true };
+    let sound = Sound { file_path: String::from("assets/images/pacman.jpeg"), can_play: true };
     let sprite = Sprite {
         position,
         size,
@@ -34,7 +35,18 @@ fn simulate_data_reception() -> Sprite {
 pub fn run_client() {
     dotenv().ok();
     let server_address = env::var("SERVER_ADDRESS").expect("SERVER_ADDRESS must be set");
-    let sprite = simulate_data_reception();
-    let json_data = serialize_to_json(&sprite);
-    send_data_to_server(&json_data, &server_address);
+    
+    let mut x = 50;
+    let mut y = -100;
+
+    for _ in 0..100 {
+        let sprite = simulate_data_reception(x, y);
+        let json_data = serialize_to_json(&sprite);
+        send_data_to_server(&json_data, &server_address);
+
+        x += 4;
+        y -= 4;
+
+        thread::sleep(Duration::from_millis(80));
+    }
 }

--- a/console/src/lib.rs
+++ b/console/src/lib.rs
@@ -12,9 +12,6 @@ use crate::frame::{Coord, Size, Sprite, Sound};
 use crate::serialization::serialize_to_json;
 use crate::socket_client::send_data_to_server;
 
-//use jni::JNIEnv;
-//use jni::objects::{JObject, JClass, JString};
-
 // Simulacion de datos
 fn simulate_data_reception() -> Sprite {
     let position = Coord { x: 10, y: 20 };
@@ -36,63 +33,3 @@ pub fn run_client() {
     let server_address = "127.0.0.1:8080";
     send_data_to_server(&json_data, server_address);
 }
-
-/* 
-// Function to extract `Coord` from a `JObject`
-fn get_coord(env: &mut JNIEnv, coord_obj: &JObject) -> Coord {
-    let x = env.get_field(coord_obj, "x", "I").unwrap().i().unwrap();
-    let y = env.get_field(coord_obj, "y", "I").unwrap().i().unwrap();
-    Coord { x, y }
-}
-
-// Function to extract `Size` from a `JObject`
-fn get_size(env: &mut JNIEnv, size_obj: &JObject) -> Size {
-    let height = env.get_field(size_obj, "height", "D").unwrap().d().unwrap();
-    let width = env.get_field(size_obj, "width", "D").unwrap().d().unwrap();
-    Size { height, width }
-}
-
-// Function to extract `Sound` from a `JObject`
-fn get_sound(env: &mut JNIEnv, sound_obj: &JObject) -> Sound {
-    let file_path_obj = env.get_field(sound_obj, "filePath", "Ljava/lang/String;").unwrap().l().unwrap();
-    let file_path: String = env.get_string(&JString::from(file_path_obj)).unwrap().into();
-    let can_play = env.get_field(sound_obj, "canPlay", "Z").unwrap().z().unwrap();
-    Sound { file_path, can_play }
-}
-
-// Function to extract `Sprite` from a `JObject`
-fn get_sprite(env: &mut JNIEnv, sprite_obj: &JObject) -> Sprite {
-    let position_obj = env.get_field(sprite_obj, "position", "LCoord;").unwrap().l().unwrap();
-    let size_obj = env.get_field(sprite_obj, "size", "LSize;").unwrap().l().unwrap();
-    let is_hidden = env.get_field(sprite_obj, "isHidden", "Z").unwrap().z().unwrap();
-    
-    let sound_obj = env.get_field(sprite_obj, "sound", "LSound;").unwrap().l();
-    let sound = match sound_obj {
-        Ok(obj) => Some(get_sound(env, &obj)),
-        Err(_) => None,
-    };
-
-    Sprite {
-        position: get_coord(env, &position_obj),
-        size: get_size(env, &size_obj),
-        is_hidden,
-        sound,
-    }
-}
-
-#[no_mangle]
-pub extern "system" fn Java_com_example_RenderHandler_handleSprite(env: JNIEnv, _: JClass, sprite_obj: JObject) {
-    let mut env = env;
-    let sprite = get_sprite(&mut env, &sprite_obj);
-    // Handle sprite in Rust
-    println!("{:?}", sprite);
-}
-
-#[no_mangle]
-pub extern "system" fn Java_com_example_RenderHandler_handleSound(env: JNIEnv, _: JClass, sound_obj: JObject) {
-    let mut env = env;
-    let sound = get_sound(&mut env, &sound_obj);
-    // Handle sound in Rust
-    println!("{:?}", sound);
-}
-*/

--- a/console/src/main.rs
+++ b/console/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/console/src/serialization.rs
+++ b/console/src/serialization.rs
@@ -1,0 +1,5 @@
+use serde_json;
+
+pub fn serialize_to_json<T: serde::Serialize>(value: &T) -> String {
+    serde_json::to_string(value).expect("Failed to serialize")
+}

--- a/console/src/socket_client.rs
+++ b/console/src/socket_client.rs
@@ -1,0 +1,14 @@
+use std::io::prelude::*;
+use std::net::TcpStream;
+
+pub fn send_data_to_server(data: &str, server_address: &str) {
+    match TcpStream::connect(server_address) {
+        Ok(mut stream) => {
+            stream.write_all(data.as_bytes()).expect("Failed to write to stream");
+            println!("Sent data to server: {}", data);
+        },
+        Err(e) => {
+            println!("Failed to connect: {}", e);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Since the US `output intermediate` is not yet implemented, in this US a simulation of data reception was made through JNI, this data was stored in structures, `Sprite` and `Sound`, which represent a `Frame`, and sent through the socket the client's.

## What did I do?
- I have created structures for `Sprite` and `Sound` that represent a `Frame`.
- I have serialized these structures to a `json` format.
- I have created the client socket, so that it sends this serialized data or this frame to the screen server socket.

## How did I do it?
- I did the serialization using the `serde` library.
- And the sockets with the standard libraries that Rust has.

## Why did I do it?
- To allow communication between the console and the screen.

## Notes
You need to add a file `.env` on the root of console with the following information: 
`SERVER_ADDRESS=127.0.0.1:8080`

### US and Task related
- US-130 -> [US 130 | Game communication](https://tree.taiga.io/project/joseluis-teran-coffeetime/us/130?milestone=394885)
- Task-141 -> [Task 141 | Socket Client](https://tree.taiga.io/project/joseluis-teran-coffeetime/task/141)