### PR TITLE
task-182/refactor-client-socket

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,9 @@ fn simulate_data_reception(x: i32, y: i32) -> Frame {
 
     Frame {
         sprite: Some(sprite),
-        sound: Some(sound),
+        sound: None,
+        // At the moment we are only sending sprite data, if you want to send sound data, uncomment the next line and comment the previous one
+        //sound: Some(sound),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use crate::socket_client::send_data_to_server;
 fn simulate_data_reception(x: i32, y: i32) -> Frame {
     let position = Coord { x, y };
     let size = Size { height: 64.0, width: 64.0 };
-    let sound = Sound { file_path: String::from("assets/sounds/pacman_sound.wav"), can_play: true };
+    let sound = Sound { file_path: String::from("assets/sounds/guitar.mp3"), can_play: true };
     let sprite = Sprite {
         position,
         size,

--- a/src/socket_client.rs
+++ b/src/socket_client.rs
@@ -1,8 +1,8 @@
 use std::io::prelude::*;
-use std::net::TcpStream;
+use std::os::unix::net::UnixStream;
 
-pub fn send_data_to_server(data: &str, server_address: &str) {
-    match TcpStream::connect(server_address) {
+pub fn send_data_to_server(data: &str, socket_path: &str) {
+    match UnixStream::connect(socket_path) {
         Ok(mut stream) => {
             stream.write_all(data.as_bytes()).expect("Failed to write to stream");
             println!("Sent data to server: {}", data);


### PR DESCRIPTION
# US: Game Comunnication
- [US-130](https://tree.taiga.io/project/joseluis-teran-coffeetime/us/130)
- [Task-182](https://tree.taiga.io/project/joseluis-teran-coffeetime/task/182)

## Description
Change of the TCP/IP socket client connection to domain unix sockets.

- #### What did I do?
- I changed the TCP/IP socket client connection to domain unix sockets.
- #### How did I do it?
-  Changing `net::TcpStream` connection to `unix::net::UnixStream` between socket.
- #### Why did I do it?
- To improve the communication time between sockets for sending Frames.
- ### Notes
- With this change you need to add a file `.env` on the root of screen with the following information: 
`SERVER_ADDRESS=/tmp/socket_console`

## Type of Change

Put an `x` in all the boxes that apply:

- [ ] ✨ New Feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug Fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking Change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code Refactor
- [ ] ✅ Build Configuration Change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Pull Request Checklist

Put an `x` in all the boxes that apply:

- [x] My commit messages are detailed.
- [x] My code follows the code style of this project.
- [x] No existing features have been broken without good reason.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
